### PR TITLE
1-hyeokbini

### DIFF
--- a/flydongwoo/README.md
+++ b/flydongwoo/README.md
@@ -2,5 +2,5 @@
  
  | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
  |:----:|:---------:|:----:|:-----:|:----:|
- | 1차시 | 2025.03.18 |  이분 탐색  | [케이크 자르기](https://www.acmicpc.net/problem/17179)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/3|
+ | 1차시 | 2025.03.18 |  이분 탐색  | [케이크 자르기](https://www.acmicpc.net/problem/12865)|https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/4|
  ---

--- a/flydongwoo/README.md
+++ b/flydongwoo/README.md
@@ -2,5 +2,5 @@
  
  | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
  |:----:|:---------:|:----:|:-----:|:----:|
- | 1차시 | 2025.03.18 |  이분 탐색  | [케이크 자르기](https://www.acmicpc.net/problem/12865)|https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/4|
+ | 1차시 | 2025.03.18 |  이분 탐색  | [케이크 자르기](https://www.acmicpc.net/problem/17179)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/3|
  ---

--- a/hyeokbini/1262.알파벳 다이아몬드/1262.cpp
+++ b/hyeokbini/1262.알파벳 다이아몬드/1262.cpp
@@ -1,0 +1,42 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int n;
+
+char calculate(int i,int j)
+{
+    int localcenter = n - 1;
+    int distance = abs(i - localcenter) + abs(j - localcenter);
+    if(distance >= n)
+    {
+        return '.';
+    }
+    else
+    {
+        return 'a' + (distance % 26);
+    }
+}
+
+int main()
+{
+    ios::sync_with_stdio(false);
+    cin.tie(0);
+    //freopen("test.txt", "rt", stdin);
+    int r1,c1,r2,c2;
+    cin >> n >> r1 >> c1 >> r2 >> c2;
+    int stand = n * 2 - 1;
+    for(int i = r1; i <= r2; i++)
+    {
+        for(int j = c1; j <= c2; j++)
+        {
+            int tempi = i % stand;
+            int tempj = j % stand;
+
+            cout << calculate(tempi,tempj);
+        }
+        cout << "\n";
+    }
+
+    return 0;
+}

--- a/hyeokbini/README.md
+++ b/hyeokbini/README.md
@@ -2,5 +2,5 @@
  
  | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
  |:----:|:---------:|:----:|:-----:|:----:|
- | 1차시 | 2025.03.18 |  이분 탐색  | [케이크 자르기](https://www.acmicpc.net/problem/17179)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/3|
+ | 1차시 | 2025.04.29 |  구현  | [알파벳 다이아몬드](https://www.acmicpc.net/problem/1262)|[#1](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/1)|
  ---


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
https://www.acmicpc.net/problem/1262
알파벳 다이아몬드

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
40분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
초기 값들을 입력받은 다음, **stand** 변수를 계산합니다.

stand 변수는 각각의 알파벳 다이아몬드들이 차지하는 가로 세로 길이입니다.
stand 변수를 계산하는 이유는, 문제에서 제시되는 다이아몬드의 모습은 무한히 연속되고, 같은 모습을 가지고 있다는 것을 알 수 있습니다.

따라서 각 문자를 전부 2차원 배열에 있는 것처럼 처리하는 것이 아니라, **각 문자의 인덱스(이 문제에서는 y좌표는 r1 ~ r2, x좌표는 c1 ~ c2가 되겠네요)를 stand값으로 나머지 처리해서 제일 처음 나오는 다이아몬드 하나로 모든 좌표값을 가져와 해당 인덱스의 문자를 확인**하는 로직을 사용했습니다.

그 후 인덱스를 체크하기 위해 이중 for문을 돌면서, 각 인덱스가 제일 첫 마름모에서의 상대적 위치가 어딘지를 tempi와 tempj에 저장합니다.

calculate 함수에서는 **마름모의 중앙 인덱스와 인자로 받은 인덱스의 맨해튼 거리**를 계산합니다. 이미지로 예시를 든다면

![image](https://github.com/user-attachments/assets/8108cc8d-4f42-48a3-b8c9-6fddf43678c1)
n = 3일 때의 마름모 모습입니다.

중앙 'a'를 기준으로, 맨해튼 거리가 늘어남에 따라 알파벳도 순서대로 나열됩니다.
거리가 n보다 크거나 같다면 '.'을 출력하면 되겠네요.
따라서 distance가 n보다 크거나 같다면 '.', n보다 작다면 'a' + (distance % 26)을 return하도록 작성했습니다.
n(stand)이 26보다 클 수 있기 때문에 a~z를 다 쓴 후 다시 a로 돌아와서 더 커지는 마름모가 존재할 수 있기 때문에 % 26을 해주었습니다.

```
입력 : n,r1,c1,r2,c2 → 초기 값들을 입력받습니다
stand 계산 → 마름모의 하나의 한 변 크기

반복 i : r1부터 r2까지:
    반복 j : c1부터 c2까지:
        tempi = i % stand → 현재 위치가 속한 타일 내의 행 좌표
        tempj = j % stand → 현재 위치가 속한 타일 내의 열 좌표
        calculate(tempi, tempj)

함수 calculate(i, j)
    center = n - 1 → 마름모의 중심점(기준점) 지정
    distance = abs(i - center)+ abs(j - center) → 중심점과 인자 좌표의 맨해튼 거리 계산
    만약 distance가 n보다 크거나 같으면:
        '.' 반환
    아니면:
        'a' + (distance % 26) 반환
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
PS를 오랜만에 해서 다시 감을 찾아보려고 단순 구현 문제를 먼저 들고와봤는데... 생각보다 막히는 부분이 많았어서 힘들었네요.
이런 2차원 배열에서의 특정 부분을 출력 혹은 묻는 류의 문제는 굳이 배열을 선언하지 않고 인덱스 기반의 풀이가 가능하다는 사실을 다시 리마인드했습니다.