### PR TITLE
1-mj010504

### DIFF
--- a/mj010504/BOJ/1012.cpp
+++ b/mj010504/BOJ/1012.cpp
@@ -1,0 +1,59 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int dx[4] = {0, 0, 1, -1};
+int dy[4] = {1, -1, 0, 0};
+
+int main() {
+   // freopen("input.txt", "rt", stdin);  
+    
+    ios::sync_with_stdio(false);
+    cin.tie(0);
+    cout.tie(0);
+
+    int t; cin >> t;
+    while(t--) {
+        int m, n, k; cin >> m >> n >> k;
+
+        int res = 0;
+        vector<vector<int>> v(n, vector<int> (m, 0));
+
+        for(int i = 0; i < k; i++) {
+            int x, y; cin >> y >> x;
+            v[x][y] = 1;
+        }
+
+        for(int i = 0; i < n; i++) {
+            for(int j = 0; j < m; j++) {
+                if(v[i][j] == 1) {
+                    res++;
+                    v[i][j] = 0;
+                    queue<pair<int, int>> q;
+                    q.push({i,j});
+                    while(!q.empty()) {
+                        auto tp = q.front();
+                        q.pop();
+
+                        for(int d = 0; d < 4; d++) {
+                            int xx = tp.first + dx[d];
+                            int yy = tp.second + dy[d];
+
+                            if(xx >= 0 && xx < n && yy >=0 && yy < m && v[xx][yy] == 1) {
+                                v[xx][yy] = 0;
+                                q.push({xx, yy});
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+
+        cout << res << '\n';
+
+    }
+
+    return 0;
+}
+

--- a/mj010504/README.md
+++ b/mj010504/README.md
@@ -2,5 +2,5 @@
  
  | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
  |:----:|:---------:|:----:|:-----:|:----:|
- | 1차시 | 2025.05.01 |  BFS/DFS  | [유기농 배추](https://www.acmicpc.net/problem/1012)|https://github.com/AlgoLeadMe/AlgoLeadMe-115/pull/1|
+ | 1차시 | 2025.05.01 |  BFS/DFS  | [유기농 배추](https://www.acmicpc.net/problem/1012)|(https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/3)|
  ---

--- a/mj010504/README.md
+++ b/mj010504/README.md
@@ -2,5 +2,5 @@
  
  | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
  |:----:|:---------:|:----:|:-----:|:----:|
- | 1차시 | 2025.03.18 |  이분 탐색  | [케이크 자르기](https://www.acmicpc.net/problem/17179)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/3|
+ | 1차시 | 2025.05.01 |  BFS/DFS  | [유기농 배추](https://www.acmicpc.net/problem/1012)|https://github.com/AlgoLeadMe/AlgoLeadMe-115/pull/1|
  ---


### PR DESCRIPTION
## 🔗 문제 링크
- 유기농 배추
https://www.acmicpc.net/problem/1012

## ✔️ 소요된 시간
30분

## ✨ 수도 코드
배추흰지렁이는 배추에 서식하고 상하좌우로 이동할 수 있으므로 배추들이 모여있는 영역에서는 배추흰지렁이가 한마리만 있어도 충분하다. 그래서 배추들이 있는 영역의 개수를 구하는 것이 이 문제의 해결책이다. 
2차원 배열에서 배추를 발견하면 영역의 개수를 +1하고, 해당 배추 위치를 시작점으로 상하좌우로 인접한 배추들을 방문 처리한다. 이러한 방식으로 중복되는 영역없이 모든 배추들을 탐색하여, 배추들의 총 영역의 개수를 구한다.

## 📚 새롭게 알게된 내용
오랜만에 PS라 다시 C++에 적응하기 위해 티어가 낮은 실버2 문제를 선택했다. 흔한 BFS로 영역 개수를 구하는 문제이지만, 문제에 영역을 구하라는 말은 없기 때문에 문제를 잘 해석해서 BFS라는걸 알아낼 수 있었다. DFS로도 충분히 풀이 가능할 것 같다.