### PR TITLE
6-mj010504

### DIFF
--- a/mj010504/BOJ/7579.cpp
+++ b/mj010504/BOJ/7579.cpp
@@ -1,0 +1,38 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int main() {
+
+   // freopen("input.txt", "rt", stdin);  
+    int n, m; cin >> n >> m;
+
+    vector<int> active(n);
+    for(int i = 0; i < n; i++) cin >> active[i];
+
+    vector<int> cost(n);
+    for(int i = 0; i < n; i++) cin >> cost[i];
+
+    int maxx = 0; // 최대 메모리 공간
+    for(int i = 0; i < n; i++) {
+        maxx += active[i];
+    }
+
+    vector<int> dp(maxx + 1, 2147900); 
+    dp[0] = 0;
+
+    for(int i = 0; i < n; i++) {
+      for(int j = maxx; j >= active[i]; j--) { // downTo 방식을 사용하여 중복 제거
+        dp[j] = min(dp[j], dp[j - active[i]] + cost[i]);
+      }
+    }
+
+    int res = INT_MAX;
+    for(int i = m; i <= maxx; i++) {
+      res = min(res, dp[i]);
+    }
+
+    cout << res;    
+
+    return 0;
+}


### PR DESCRIPTION
## 🔗 문제 링크
앱
https://www.acmicpc.net/problem/7579

## ✔️ 소요된 시간
1시간 30분

## ✨ 수도 코드
- 이미 활성화된 앱에서 앱들을 비활성화 시켜서 M의 메모리 만큼 공간을 확보하는 문제이다.
- 문제를 보고 앱이 메모리를 차지하는 공간, 비활성화시 드는 비용 등에 대한 조건을 보았을 때 배낭 문제가 떠올랐다. 이 문제를 배낭 문제와 같이 대입해보면, 기존 배낭 문제와는 달리 배낭에 물건을 추가하는 것이 아닌 **배낭에서 물건을 빼야한다.**
- 우선 **최대 메모리의 크기**는 문제에서 명시되어있지 않지만 **현재 활성화된 앱의 메모리 공간의 합**으로 구했다.
- 따라서 문제를 **이미 꽉찬 배낭에서 물건을 빼서 공간을 확보하되 그 비용의 합이 최소가 되도록 하는 문제**라고 생각했고, dp 배열에는 해당 공간을 확보할 때 드는 최소 비용을 저장하도록 했다.
- dp[0] 은 공간 0 확보시 드는 비용이 0이므로 0으로 초기화하였다.
- 답은 dp 배열에서 M이상에서 가장 작은 dp 값을 출력하도록 했다. M 이상인 이유는 앱들이 차지하는 메모리 공간에 따라 확보하고자 하는 공간인 M이랑 완전히 일치하지 않을 수 있기 때문이다. 최악의 경우 M은 앱의 최대 메모리 공간(배낭의 최대 무게)일 수 있기 때문에 M 이상부터 탐색하여 최솟값을 출력하도록 하였다.

### 여담
- 문제를 푸는데 시간이 좀 걸렸는데 배낭 문제에 대한 개념을 확실히 정리하고 푼다고 오래걸렸다.
- 이 문제는 일차원 배열로도, 이차원 배열로도 풀 수 있을 것 같다. 하지만 저번에 동우님이 올려주신 **평범한 배낭** 문제에서 이차원 배열을 사용하지 않고 일차원 배열로도 풀 수 있는 방법을 제시해주셔서 해당 방법과 유사하게 **앱을 중복으로 비활성화 시키는 것을 방지**할 수 있었다. 좋은 풀이법을 알려주신 동우님께 감사드립니다!

## 📚 새롭게 알게된 내용
- 배열을 downTo 방식으로 접근하여 중복되는 행동을 방지할 수 있다는 것을 다시 리마인드했다.
