### PR TITLE
8-jiseob

### DIFF
--- a/seobeeeee1001/DP/.cph/.7579.cpp_4d95daa6b578260aaf4340cec86949ea.prob
+++ b/seobeeeee1001/DP/.cph/.7579.cpp_4d95daa6b578260aaf4340cec86949ea.prob
@@ -1,0 +1,1 @@
+{"name":"Local: 7579","url":"c:\\Users\\User\\Desktop\\wjs\\알고리즘 스터디\\AlgoLeadMe-15\\seobeeeee1001\\DP\\7579.cpp","tests":[{"id":1749874247446,"input":"5 60\n30 10 20 35 40\n3 0 3 5 4","output":""}],"interactive":false,"memoryLimit":1024,"timeLimit":3000,"srcPath":"c:\\Users\\User\\Desktop\\wjs\\알고리즘 스터디\\AlgoLeadMe-15\\seobeeeee1001\\DP\\7579.cpp","group":"local","local":true}

--- a/seobeeeee1001/DP/1912.cpp
+++ b/seobeeeee1001/DP/1912.cpp
@@ -16,5 +16,5 @@ int main() {
         d[i] = max(0,d[i-1]) + arr[i];    
     }
     cout<<*max_element(d+1,d+1+n);
-
+    
 }

--- a/seobeeeee1001/DP/7579.cpp
+++ b/seobeeeee1001/DP/7579.cpp
@@ -1,0 +1,36 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int mem[104];
+int c[104];
+
+vector<vector<int>> d;
+
+int main(){
+    int n,m;
+    cin>>n>>m;
+    d.resize(n+1, vector<int>(m, 101));
+    for(int i=0;i<n;i++){
+        cin>>mem[i];
+    }
+    for(int i=0;i<n;i++){
+        cin>>c[i];
+    }
+
+    for(int i=0;i<n;i++){
+        for(int j=1;j<=m;j++){
+            if(i-1>=0){
+                if(j-mem[i]<=0) d[i][j] = min(c[i],d[i-1][j]);
+                else d[i][j] = min(d[i-1][j],d[i-1][j-mem[i]]);
+                cout<<i<<" "<<j<<"\n";
+            }
+            else{
+                if(j-mem[i]<=0) d[i][j] = c[i];
+                else continue;
+                cout<<i<<" "<<j<<"\n";
+            }
+        }
+    }
+
+    cout<<d[n-1][m];
+}

--- a/seobeeeee1001/README.md
+++ b/seobeeeee1001/README.md
@@ -9,4 +9,5 @@
  | 5차시 | 2025.05.12 | DP | [2×n 타일링 2](https://www.acmicpc.net/problem/11727)|https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/22|
  | 6차시 | 2025.06.12 | DP | [이친수](https://www.acmicpc.net/problem/2193)|https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/33|
  | 7차시 | 2025.06.15 | DP | [연속합](https://www.acmicpc.net/problem/1912)|https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/34|
+ | 8차시 | 2025.07.09 | 그리디 | [동전 0](https://www.acmicpc.net/problem/11047)|https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/42|
  ---

--- a/seobeeeee1001/그리디/11047.cpp
+++ b/seobeeeee1001/그리디/11047.cpp
@@ -1,0 +1,18 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int n, k;
+int a[15];
+
+int main(void){
+  ios::sync_with_stdio(0);
+  cin.tie(0);
+  int ans = 0;
+  cin >> n >> k;
+  for(int i = 0; i < n; i++) cin >> a[i];
+  for(int i = n-1; i >= 0; i--){
+    ans += k / a[i];
+    k %= a[i];
+  }
+  cout << ans;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->

https://www.acmicpc.net/problem/11047

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->

10분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

### DP 접근

처음엔 DP로도 풀 수 있겠다 싶어서

 점화식을 d[i] = min ( d[i-A1] , d[i-A2] , ... , d[i-AN] ) + 1 과 같이 세워봤습니다.

그런데 K 가 1억이라 NK가 10억이 돼서 시간초과가 발생합니다.

### 그리디 접근 

그 다음으로 생각할 수 있는건 그리디입니다.

직관적으로 가치가 큰 동전 순서대로 최대한으로 쓰면 사용하는 동전의 개수가 최소가 됩니다.

그렇지만 그리디는 연습할 때는 간단한 증명이라도 하는게 나중에 실전에서 좋다고해서 한번 해보겠습니다.

10원 50원 100원 500원이 있다고 했을 때,

**명제** : 500원을 최대한으로 많이 써야한다.

명제를 증명하기 전에 보조정리를 증명해보겠습니다.

**보조 정리** : 

10원/100원은 4개 이하로 사용해야합니다

50원은 1개 이하로 사용해야합니다.

귀류법으로 10원, 100원을 5개 이상으로 쓴다면

50원이나 500원으로 대체가능합니다.

50원도 2개 이상 쓰면 100원으로 대체가능합니다.

따라서 보조 정리를 따라야 개수가 최적화된다는 것을 알 수 있습니다.

보조 정리를 통해서 우리는 10원/50원/100원으로 최대한 만들 수 있는 액수가 490원인 것을 알 수 있습니다.

즉, 500원을 감당하지 못하기 때문에 500원을 최대한 많이 사용해야므로 명제가 증명이 됩니다.

100원, 50원, 10원에도 마찬가지의 논리를 적용할 수 있으므로 차례대로 사용하면 됩니다.

일반적인 상황에서도 증명이 되냐 의문이 든다면 

문제에서  배수 관계가 있다는 조건이 있으므로 대체 가능성, 어떤 숫자보다 작은 배수 관계 숫자들의 합이 그 수 보다 작다는 것을 확인한다면 의문이 풀리실 겁니다. (예를 들어 1,2,4,8,16 에서는 8까지 더해도 15가 됩니다.)


## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

