### PR TITLE
16-hyeokbini

### DIFF
--- a/hyeokbini/16719.ZOAC/16719.cpp
+++ b/hyeokbini/16719.ZOAC/16719.cpp
@@ -1,0 +1,44 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+vector<bool> visited; // 출력 인덱스 사용 여부 검사용
+
+void func(string tmp, int startidx, int endidx)
+{
+    if(startidx > endidx)
+    {
+        return;
+    }
+    int minidx = startidx; // 가장 사전순으로 앞서는 문자의 인덱스, startidx로 초기화
+    for(int i = startidx; i <= endidx; i++)
+    {
+        if(tmp[minidx] > tmp[i])
+        {
+            minidx = i; // 범위 내에서 가장 사전순으로 앞서는 문자 찾기
+        }
+    }
+    visited[minidx] = true;
+    for(int i = 0; i < tmp.length(); i++)
+    {
+        if(visited[i])
+        {
+            cout << tmp[i];
+        }
+    }
+    cout << "\n";
+
+    func(tmp,minidx + 1,endidx); // 뒤쪽부터 탐색
+    func(tmp,startidx,minidx - 1); // 앞쪽 탐색
+}
+
+int main()
+{
+    ios::sync_with_stdio(false);
+    cin.tie(0);
+    //freopen("test.txt", "rt", stdin);
+    string tmp;
+    cin >> tmp;
+    visited.resize(tmp.length(),false);
+    func(tmp,0,tmp.length() - 1);
+    return 0;   
+}

--- a/hyeokbini/README.md
+++ b/hyeokbini/README.md
@@ -16,3 +16,4 @@
  | 12차시 | 2025.07.13 |  백트래킹  | [부분수열의 합](https://www.acmicpc.net/problem/1182)|[#10](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/45)|
  | 13차시 | 2025.07.16 |  백트래킹  | [색종이 붙이기](https://www.acmicpc.net/problem/17136)|[#13](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/47)|
  | 14차시 | 2025.07.22 |  백트래킹  | [숌 사각형](https://www.acmicpc.net/problem/1481)|[#14](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/50)|
+ | 16차시 | 2025.07.29 |  구현, 재귀  | [ZOAC](https://www.acmicpc.net/problem/16719)|[#14](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/57)|


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
골드5
ZOAC
https://www.acmicpc.net/problem/16719

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
30분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
구현 연습을 한번 더 해보려고 구현 태그만 달고 검색한 뒤 문제를 골랐는데 희한하게 또 재귀함수를 이용하는 문제였네요.

문제에서 요구하는 출력은, 문자열에서 문자를 하나씩 사용해 완성된 문자열을 만드는 과정을 출력하되, **모든 과정 속 단어들이 사전순으로 정렬**되어 있음을 요구합니다.

사전순 출력을 생각해봤을 때, 생각해봐야할 것은

* 단어를 이루는 한 문자의 사전순 순서
* 단어를 이루는 한 문자의 상대적 위치
* 단어의 길이

를 고려해봐야 합니다.

해당 문제에서 요구하는 조건을 맞추려면, 어차피 길이는 i번째 출력보다 i+1번째 출력이 더 길 수밖에 없으니 고려하지 않겠습니다.

고려해야 할 사항은 문자의 사전순 순서와, 상대적 위치인데 제일 첫 케이스를 생각한다면, 당연히 문자 중 사전순으로 제일 앞서는 것이 맨 첫번째 출력이 되어야 합니다.

그 다음부터 핵심 아이디어는, **맨 첫번째에 사용했던 사전순으로 제일 앞서는 문자의 뒤에서부터 다시 사전순으로 제일 앞서는 문자를 찾는다**입니다.

글로 적으려니 전달이 조금 부족할 것 같아서, 간단한 예시를 들어보았습니다.

BBBBADCE라는 문자열이 있다면, 당연히 첫 출력은 A일 겁니다.

이때 이 A를 기준으로, **왼쪽에 있는 어떠한 문자를 사용해선 안 됩니다.** 설령 B가 C보다 사전순으로 앞선다 해도 B가 A의 앞에 들어가는 순간, A의 상대적 위치가 뒤로 밀려나 사전순으로 뒤에 밀리는 단어가 됩니다.

따라서 A의 오른쪽 부분에서 다시 사전순으로 제일 앞쪽에 있는 문자를 찾으면, C가 나오므로 두번째 출력은 AC가 됩니다.

D와 E를 비교할 때도 마찬가지로, 

* D를 먼저 사용하는 경우 : ADC
* E를 먼저 사용하는 경우 : ACE

A와 C는 동일하고, D는 E보다 사전순으로 앞서지만 문자의 상대적 위치 때문에 D를 사용해선 안 되고, 무조건 오른쪽에 있는 E를 사용해야 합니다.

그리고 맨 마지막 인덱스까지 돌았다면, 왼쪽에 있는 부분들에 대해서도 동일한 로직을 적용해주면 됩니다. 

재귀함수 하나면 구현할 수 있는데, startidx와 endidx를 인자로 받고 해당 범위 내에서 가장 사전순으로 앞서는 문자를 추가해나가는 방식을 사용하면 됩니다. 이 부분은 전역변수 visited 벡터를 이용해 각 재귀의 깊이마다 visited에 체크된 문자만 출력하도록 구현했습니다.

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
골드 5치고는 생각보다 스무스하게 풀려서 놀랐습니다. 다만 **무조건 오른쪽부터 탐색**이라는 규칙성을 발견해내지 못했다면 여러모로 삽질하고 있었을 것 같네요. 일단 오른쪽부터 탐색한다라는 게 그리디 느낌도 나는 것 같습니다..?