### PR TITLE
17-hyeokbini

### DIFF
--- a/hyeokbini/2447,8. 별 찍기 10,11/2447.cpp
+++ b/hyeokbini/2447,8. 별 찍기 10,11/2447.cpp
@@ -1,0 +1,50 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int n;
+vector<vector<char>> arr;
+
+void func(int curlength, int curxstart, int curystart)
+{
+    // 기저 조건(curlength가 1)
+    if (curlength == 1)
+    {
+        // 현재 칸을 별로 색칠
+        arr[curxstart][curystart] = '*';
+        return;
+    }
+
+    // 현재 길이를 3등분해서 기준으로 삼을 값
+    int newlength = curlength / 3;
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            // 중간 부분은 별을 찍지 않음
+            if (i == 1 && j == 1)
+            {
+                continue;
+            }
+            func(newlength, curxstart + newlength * i, curystart + newlength * j);
+        }
+    }
+}
+
+int main()
+{
+    ios::sync_with_stdio(false);
+    cin.tie(0);
+    //freopen("test.txt", "rt", stdin);
+    cin >> n;
+    arr.resize(n, vector<char>(n,' '));
+    func(n, 0, 0); // 인자는 현재 사각형 길이, 좌상단 시작점 좌표
+    for(int i = 0; i < n; i++)
+    {
+        for(int j = 0; j < n; j++)
+        {
+            cout << arr[i][j];
+        }
+        cout << "\n";
+    }
+    return 0;
+}

--- a/hyeokbini/2447,8. 별 찍기 10,11/2448.cpp
+++ b/hyeokbini/2447,8. 별 찍기 10,11/2448.cpp
@@ -1,0 +1,52 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int n;
+vector<vector<char>> arr;
+
+void drawdot(int x, int y)
+{
+    // 인자로 받은 x,y 값은 삼각형 위쪽 꼭짓점
+    arr[x][y] = '*';
+    arr[x + 1][y - 1] = '*';
+    arr[x + 1][y + 1] = '*';
+    arr[x + 2][y - 2] = '*';
+    arr[x + 2][y - 1] = '*';
+    arr[x + 2][y] = '*';
+    arr[x + 2][y + 1] = '*';
+    arr[x + 2][y + 2] = '*';
+    return;
+}
+
+void func(int curheight, int curx, int cury)
+{
+    // 사각형 높이가 3이 된다면 기저조건
+    if (curheight == 3)
+    {
+        drawdot(curx, cury);
+        return;
+    }
+    int newheight = curheight / 2;
+    func(newheight, curx, cury); // 삼각형 위쪽 중앙
+    func(newheight, curx + newheight, cury + newheight); // 삼각형 오른쪽 아래
+    func(newheight, curx + newheight, cury - newheight); // 삼각형 왼쪽 아래
+}
+
+int main()
+{
+    ios::sync_with_stdio(false);
+    cin.tie(0);
+    //freopen("test.txt", "rt", stdin);
+    cin >> n;
+    arr.resize(n, vector<char>(2 * n - 1, ' '));
+    func(n, 0, n - 1); // 인자는 현재 전체 사각형 높이, 삼각형의 맨 위 꼭짓점 위치
+    for (int i = 0; i < n; i++)
+    {
+        for (int j = 0; j < n * 2 - 1; j++)
+        {
+            cout << arr[i][j];
+        }
+        cout << "\n";
+    }
+    return 0;
+}

--- a/hyeokbini/README.md
+++ b/hyeokbini/README.md
@@ -18,3 +18,5 @@
  | 14차시 | 2025.07.22 |  백트래킹  | [숌 사각형](https://www.acmicpc.net/problem/1481)|[#14](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/50)|
  | 15차시 | 2025.07.22 |  그리디, 수학  | [세 수, 두 M](https://www.acmicpc.net/problem/2405)|[#15](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/56)|
  | 16차시 | 2025.07.29 |  구현, 재귀  | [ZOAC](https://www.acmicpc.net/problem/16719)|[#16](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/57)|
+ | 17차시 | 2025.08.03 | 구현, 재귀 | [별 찍기 - 10](https://www.acmicpc.net/problem/2447)<br>[별 찍기 - 11](https://www.acmicpc.net/problem/2448) | [#17](https://github.com/AlgoLeadMe/AlgoLeadMe-15/pull/59) |
+


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
골드 5
[별 찍기 10](https://www.acmicpc.net/problem/2447)

골드 4
[별 찍기 11](https://www.acmicpc.net/problem/2448)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
별 찍기 10 : 30분
별 찍기 11 : 40분

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
이번에는 [별 찍기 시리즈](https://www.acmicpc.net/workbook/view/20) 중에서 난이도가 꽤 있다고 평가받는 10번, 11번 문제를 가져와 보았습니다.

두 문제 모두 풀어보시면 도움이 될 것 같지만, 개인적으로는 11번이 더 난이도 있고 생각할 여지도 많다고 생각해서 11번을 우선적으로 풀어보시는 걸 추천드립니다!

<hr>

### 별 찍기 - 10

문제에서 요구하는 사항 자체는 이해하기 크게 어려운 부분은 없습니다. 정사각형 모양의 격자가 주어지면 9등분 했을 때 중앙 부분을 비우고, 나머지 부분들에 있어서 또 9등분 후 중앙을 비우고... 하는 방식입니다. 

문제 자체에서도 재귀를 언급하고 있고, 별을 찍는 전체 패턴이 작은 패턴의 반복으로 이루어지는 경향성이 있기 때문에 재귀함수를 써서 풀이하는 아이디어를 떠올릴 수 있습니다.

여기에서 함수를 설계할 때 다양한 아이디어를 사용할 수 있지만, 저는 함수의 인자로

* 현재 주어진 정사각형의 한 변의 길이
* 현재 주어진 정사각형의 좌측 상단 x좌표
* 현재 주어진 정사각형의 좌측 상단 y좌표

이 3가지를 인자로 주고, 기저 조건을 정사각형의 한 변의 길이가 1이 되는 시점으로 선택했습니다.

만약 변의 길이가 1이 아니라면, 주어진 정사각형의 가로 / 세로를 3등분해 총 9등분으로 나눈 후 다음 중간 지점에서는 재귀를 호출하지 않고(별을 찍지 않고) 나머지 지점에서는 다시 작은 정사각형의 크기에 맞춰 재귀를 호출하는 방식을 사용했습니다.

<hr>

### 별 찍기 - 11

10번이 생각보다 쉽게 풀려서 11번도 풀어볼까 했는데 10번보다는 약간 더 어려웠던 것 같습니다. 

우선 예제 출력부터가 10번보다 훨씬 난해해 보입니다.

<img width="521" height="624" alt="image" src="https://github.com/user-attachments/assets/d4830f80-5b1b-4171-a412-66ee2fff2c10" />

우선 10번이랑 결이 비슷하게 전체 패턴이 작은 패턴의 반복으로 이루어지는 경향성이 충분히 보이기에, 기저 조건에서 사용해야 하는 패턴을 확인했습니다.

<img width="328" height="114" alt="image" src="https://github.com/user-attachments/assets/c78bca4e-3445-47e3-be2d-dd678740de32" />

여기에서는 특별히 사용할 만한 규칙성은 없어 보여서, 나중에 하드코딩으로 점을 찍어야겠다는 것 정도만 체크한 후, 다음 두 단계 정도만 직접 그림을 그려보았습니다.

<img width="773" height="625" alt="image" src="https://github.com/user-attachments/assets/bae0a141-15a3-4a64-bcc4-3f06a6d2a05d" />

엑셀로 그려서인지 그림이 좀 난잡하네요...

우선 바로 다음 단계(2번째 그림)을 보면, 기저조건의 그림이 오른쪽 아래, 왼쪽 아래에 1개씩 더 붙은 모양이구나 라고 생각할 수 있습니다.

그리고 그 다음 단계(3번째 그림)에서도 마찬가지로, 2단계의 그림이 오른쪽 아래, 왼쪽 아래에 1개씩 더 붙은 모양으로 볼 수 있습니다.

따라서 재귀의 한 깊이당 함수 호출을 3번 해주되, 기준 인덱스만 바꿔서 호출하면 될 것 같다는 아이디어를 얻었습니다.

여기서는 또 방법이 다양하게 나뉠 수 있을 것 같은데, 저는 **격자 사각형의 높이**와 **삼각형의 맨 위 꼭짓점 x,y 좌표**를 인자로 줬습니다.

<img width="438" height="382" alt="image" src="https://github.com/user-attachments/assets/7d612ad0-bcbf-4b9e-b803-3bd8ef350025" />

높이를 절반씩 줄이면서, 줄어든 높이의 값만큼 왼쪽 / 오른쪽으로 좌표를 이동시킨 인덱스가 새로운 재귀함수의 호출점이 됩니다. (그림을 보시면 빨간 사각형은 정사각형입니다)

최종적으로 사각형의 높이가 3이 된다면 주어진 모양을 해당 부분에 입력해주면 됩니다!

<hr>

이사람 또 재귀 문제 가져왔네 하실 수 있을 것 같습니다... 그런데 최근에 연습을 꽤 한 만큼 예전에는 못 풀었던 10,11을 자력으로 풀어보고 싶었습니다 😄 크게 난이도가 있는 문제는 아니니 팀원 분들도 한번 가볍게 자력솔 도전해보시면 좋을 것 같아요!

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
